### PR TITLE
Add spacing on right of notebook gird for increase visual appeal

### DIFF
--- a/frontend/src/features/notes/pages/NotebooksPage.tsx
+++ b/frontend/src/features/notes/pages/NotebooksPage.tsx
@@ -215,7 +215,7 @@ function NotebooksPage() {
 					</Dialog>
 				</div>
 
-				<div className="grid grid-cols-5 gap-4 mt-2">
+				<div className="grid grid-cols-4 gap-4 mt-2 pr-8">
 					{notebooks.map(({ name, id, notebookColor }) => (
 						<Notebook
 							notebookName={name}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Notebooks page layout to display four notebooks per row instead of five, adding right-side padding for improved spacing. This update enhances readability, reduces visual clutter, and provides a cleaner grid presentation on larger screens. It aligns the page with current design spacing guidelines and offers a more consistent appearance across viewport sizes. No functional behavior or notebook rendering logic was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->