### PR TITLE
Ensure that queries are invalidated so that fresh notebook data is re…

### DIFF
--- a/frontend/src/features/noteTaking/hooks/mutations/useNotebookMutations.hooks.ts
+++ b/frontend/src/features/noteTaking/hooks/mutations/useNotebookMutations.hooks.ts
@@ -27,7 +27,7 @@ function useNotebookMutations() {
                 : [notebookCreateResponse.createdNotebook]
         );
 
-        queryClient.invalidateQueries({
+        await queryClient.invalidateQueries({
             queryKey: ["notebooks"],
         });
     }
@@ -54,7 +54,7 @@ function useNotebookMutations() {
                 : []
         );
 
-        queryClient.invalidateQueries({
+        await queryClient.invalidateQueries({
             queryKey: ["notebooks"],
         });
     }
@@ -71,7 +71,7 @@ function useNotebookMutations() {
                 : []
         );
 
-        queryClient.invalidateQueries({
+        await queryClient.invalidateQueries({
             queryKey: ["notebooks"],
         });
     }

--- a/frontend/src/features/noteTaking/hooks/mutations/useNotebookMutations.hooks.ts
+++ b/frontend/src/features/noteTaking/hooks/mutations/useNotebookMutations.hooks.ts
@@ -26,6 +26,10 @@ function useNotebookMutations() {
                 ? [...oldNotebooks, notebookCreateResponse.createdNotebook]
                 : [notebookCreateResponse.createdNotebook]
         );
+
+        queryClient.invalidateQueries({
+            queryKey: ["notebooks"],
+        });
     }
 
     async function handleNotebookEdit(
@@ -49,6 +53,10 @@ function useNotebookMutations() {
                   )
                 : []
         );
+
+        queryClient.invalidateQueries({
+            queryKey: ["notebooks"],
+        });
     }
 
     async function handleNotebookDelete(notebookId: number) {
@@ -62,6 +70,10 @@ function useNotebookMutations() {
                 ? oldNotebooks.filter((notebook) => notebook.id !== notebookId)
                 : []
         );
+
+        queryClient.invalidateQueries({
+            queryKey: ["notebooks"],
+        });
     }
 
     return {


### PR DESCRIPTION
…-fetched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The notebooks list now refreshes immediately after creating, editing, or deleting a notebook, preventing stale data from being shown.
  - Ensures the latest notebook titles, counts, and ordering are accurately reflected without requiring a manual refresh.
  - Reduces instances of mismatched state between the UI and server, improving consistency across views and sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->