### PR TITLE
Fix/nested interactive elements

### DIFF
--- a/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
+++ b/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
@@ -43,7 +43,7 @@ function NotebookCard({
                 <NotebookIcon size={20} />
             </button>
 
-            <div className="flex flex-col flex-1 min-w-0 ml-3 mr-3">
+            <button className="flex flex-col flex-1 min-w-0 ml-3 mr-3">
                 <p className="font-semibold text-left break-words">
                     {notebookName}
                 </p>
@@ -53,7 +53,7 @@ function NotebookCard({
                         {noteCount} {getNoun()}
                     </p>
                 </div>
-            </div>
+            </button>
 
             <NotebookDropdownMenu notebookId={notebookId} />
         </div>

--- a/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
+++ b/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
@@ -1,7 +1,6 @@
 import NotebookIcon from "@/shared/components/icons/NotebookIcon";
 import NotebookDropdownMenu from "./NotebookDropdownMenu";
 import { useNavigate } from "react-router-dom";
-import { Button } from "@/components/ui/button";
 
 interface NotebookProps {
     notebookName: string;
@@ -35,7 +34,7 @@ function NotebookCard({
             aria-label={`Open notebook ${notebookName}`}
             className="flex flex-row py-3 pl-3 pr-2 bg-white rounded-2xl shadow-xl items-center hover:cursor-pointer"
         >
-            <Button
+            <button
                 type="button"
                 style={{ backgroundColor: notebookColor }}
                 onClick={handleNotebookCardClick}
@@ -43,9 +42,9 @@ function NotebookCard({
                 className="p-1 w-max h-max rounded-md bg-gray-300 hover:cursor-pointer"
             >
                 <NotebookIcon size={20} />
-            </Button>
+            </button>
 
-            <Button onClick={handleNotebookCardClick} type="button" className="flex flex-col flex-1 min-w-0 ml-3 mr-3 hover:cursor-pointer">
+            <button onClick={handleNotebookCardClick} type="button" className="flex flex-col flex-1 min-w-0 ml-3 mr-3 hover:cursor-pointer">
                 <p className="font-semibold text-left break-words">
                     {notebookName}
                 </p>
@@ -55,7 +54,7 @@ function NotebookCard({
                         {noteCount} {getNoun()}
                     </p>
                 </div>
-            </Button>
+            </button>
 
             <NotebookDropdownMenu notebookId={notebookId} />
         </div>

--- a/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
+++ b/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
@@ -39,12 +39,16 @@ function NotebookCard({
                 style={{ backgroundColor: notebookColor }}
                 onClick={handleNotebookCardClick}
                 aria-label={`Open notebook ${notebookName}`}
-                className="p-1 w-max h-max rounded-md bg-gray-300 hover:cursor-pointer"
+                className="p-1 w-max h-max rounded-md hover:cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-sky-500"
             >
                 <NotebookIcon size={20} />
             </button>
 
-            <button onClick={handleNotebookCardClick} type="button" className="flex flex-col flex-1 min-w-0 ml-3 mr-3 hover:cursor-pointer">
+            <button
+                onClick={handleNotebookCardClick}
+                type="button"
+                className="flex flex-col flex-1 min-w-0 ml-3 mr-3 hover:cursor-pointer"
+            >
                 <p className="font-semibold text-left break-words">
                     {notebookName}
                 </p>

--- a/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
+++ b/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
@@ -32,18 +32,18 @@ function NotebookCard({
     return (
         <div
             aria-label={`Open notebook ${notebookName}`}
-            onClick={handleNotebookCardClick}
             className="flex flex-row py-3 pl-3 pr-2 bg-white rounded-2xl shadow-xl items-center hover:cursor-pointer"
         >
             <button
                 type="button"
                 style={{ backgroundColor: notebookColor }}
+                onClick={handleNotebookCardClick}
                 className="p-1 w-max h-max rounded-md bg-gray-300"
             >
                 <NotebookIcon size={20} />
             </button>
 
-            <button className="flex flex-col flex-1 min-w-0 ml-3 mr-3">
+            <button onClick={handleNotebookCardClick} className="flex flex-col flex-1 min-w-0 ml-3 mr-3">
                 <p className="font-semibold text-left break-words">
                     {notebookName}
                 </p>

--- a/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
+++ b/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
@@ -1,6 +1,7 @@
 import NotebookIcon from "@/shared/components/icons/NotebookIcon";
 import NotebookDropdownMenu from "./NotebookDropdownMenu";
 import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
 
 interface NotebookProps {
     notebookName: string;
@@ -34,7 +35,7 @@ function NotebookCard({
             aria-label={`Open notebook ${notebookName}`}
             className="flex flex-row py-3 pl-3 pr-2 bg-white rounded-2xl shadow-xl items-center hover:cursor-pointer"
         >
-            <button
+            <Button
                 type="button"
                 style={{ backgroundColor: notebookColor }}
                 onClick={handleNotebookCardClick}
@@ -42,9 +43,9 @@ function NotebookCard({
                 className="p-1 w-max h-max rounded-md bg-gray-300 hover:cursor-pointer"
             >
                 <NotebookIcon size={20} />
-            </button>
+            </Button>
 
-            <button onClick={handleNotebookCardClick} className="flex flex-col flex-1 min-w-0 ml-3 mr-3 hover:cursor-pointer">
+            <Button onClick={handleNotebookCardClick} type="button" className="flex flex-col flex-1 min-w-0 ml-3 mr-3 hover:cursor-pointer">
                 <p className="font-semibold text-left break-words">
                     {notebookName}
                 </p>
@@ -54,7 +55,7 @@ function NotebookCard({
                         {noteCount} {getNoun()}
                     </p>
                 </div>
-            </button>
+            </Button>
 
             <NotebookDropdownMenu notebookId={notebookId} />
         </div>

--- a/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
+++ b/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
@@ -38,12 +38,12 @@ function NotebookCard({
                 type="button"
                 style={{ backgroundColor: notebookColor }}
                 onClick={handleNotebookCardClick}
-                className="p-1 w-max h-max rounded-md bg-gray-300"
+                className="p-1 w-max h-max rounded-md bg-gray-300 hover:cursor-pointer"
             >
                 <NotebookIcon size={20} />
             </button>
 
-            <button onClick={handleNotebookCardClick} className="flex flex-col flex-1 min-w-0 ml-3 mr-3">
+            <button onClick={handleNotebookCardClick} className="flex flex-col flex-1 min-w-0 ml-3 mr-3 hover:cursor-pointer">
                 <p className="font-semibold text-left break-words">
                     {notebookName}
                 </p>

--- a/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
+++ b/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
@@ -30,18 +30,18 @@ function NotebookCard({
     }
 
     return (
-        <button
+        <div
             aria-label={`Open notebook ${notebookName}`}
-            type="button"
             onClick={handleNotebookCardClick}
             className="flex flex-row py-3 pl-3 pr-2 bg-white rounded-2xl shadow-xl items-center hover:cursor-pointer"
         >
-            <div
+            <button
+                type="button"
                 style={{ backgroundColor: notebookColor }}
                 className="p-1 w-max h-max rounded-md bg-gray-300"
             >
                 <NotebookIcon size={20} />
-            </div>
+            </button>
 
             <div className="flex flex-col flex-1 min-w-0 ml-3 mr-3">
                 <p className="font-semibold text-left break-words">
@@ -56,7 +56,7 @@ function NotebookCard({
             </div>
 
             <NotebookDropdownMenu notebookId={notebookId} />
-        </button>
+        </div>
     );
 }
 

--- a/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
+++ b/frontend/src/features/noteTaking/pages/NotebooksPage/components/NotebookCard.tsx
@@ -38,6 +38,7 @@ function NotebookCard({
                 type="button"
                 style={{ backgroundColor: notebookColor }}
                 onClick={handleNotebookCardClick}
+                aria-label={`Open notebook ${notebookName}`}
                 className="p-1 w-max h-max rounded-md bg-gray-300 hover:cursor-pointer"
             >
                 <NotebookIcon size={20} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Notebook card interaction updated: outer card is no longer clickable; navigation now occurs via two distinct inner targets (icon and content), making clicks more intentional.
  * Interaction model changed; dropdown and destinations remain unchanged.

* **Style**
  * Added hover cursor cues on icon and content to signal interactivity.

* **Accessibility**
  * Changed interactive structure may affect screen-reader/tab order; review recommended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->