### PR TITLE
Add spacing at the bottom for title node

### DIFF
--- a/frontend/src/app/editor.css
+++ b/frontend/src/app/editor.css
@@ -3,6 +3,10 @@
         h1 {
             @apply text-3xl font-bold;
         }
+
+        h1.title {
+            @apply mb-3
+        }
         
         h2 {
             @apply text-2xl font-bold;

--- a/frontend/src/app/editor.css
+++ b/frontend/src/app/editor.css
@@ -5,7 +5,7 @@
         }
 
         h1.title {
-            @apply mb-3
+            @apply mb-3;
         }
         
         h2 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing for titles in the notes editor by adding a bottom margin to h1 elements with the “title” class.
  * Ensures consistent visual rhythm with other headings, reducing cramped layouts and enhancing readability.
  * Purely cosmetic; no functional changes to editing or content behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->