### PR TITLE
Refactor/navigation save hook

### DIFF
--- a/frontend/src/features/noteTaking/editor/hooks/editor/useNavigateSave.hooks.ts
+++ b/frontend/src/features/noteTaking/editor/hooks/editor/useNavigateSave.hooks.ts
@@ -1,0 +1,34 @@
+import { isNullOrUndefined } from "@/shared/utils/types.utils";
+import { useEffect } from "react";
+import { Editor } from "@tiptap/react";
+import { parseSerializedBlocks } from "../../utils/blocks.utils";
+import type { TiptapSerializedBlocks } from "../../types/blockSchema.types";
+import useBlockMutations from "../../hooks/blocks/useBlockMutations.hooks";
+import useLatest from "@/shared/hooks/useLatest.hooks";
+
+function useNavigateSave(editor: Editor, noteId: number) {
+    const { handleBlocksBulkUpdate } = useBlockMutations();
+    const blocksBulkUpdateCallbackRef = useLatest(handleBlocksBulkUpdate);
+
+    useEffect(() => {
+        return () => {
+            if (isNullOrUndefined(noteId)) return;
+            if (Number.isNaN(noteId)) return;
+            if (!Number.isFinite(noteId)) return;
+
+            if (!editor) return;
+            if (editor.isEmpty) return;
+
+            const serializedBlocks = parseSerializedBlocks(
+                editor.getJSON().content as TiptapSerializedBlocks
+            );
+
+            blocksBulkUpdateCallbackRef.current(
+                serializedBlocks,
+                noteId
+            );
+        };
+    }, [editor]);
+}
+
+export default useNavigateSave;

--- a/frontend/src/features/noteTaking/editor/hooks/editor/useSaveOnNavigate.hooks.ts
+++ b/frontend/src/features/noteTaking/editor/hooks/editor/useSaveOnNavigate.hooks.ts
@@ -1,4 +1,3 @@
-import { isNullOrUndefined } from "@/shared/utils/types.utils";
 import { useEffect } from "react";
 import { Editor } from "@tiptap/react";
 import { parseSerializedBlocks } from "../../utils/blocks.utils";
@@ -14,9 +13,8 @@ function useSaveOnNavigate(editor: Editor, noteId: number) {
 
     useEffect(() => {
         return () => {
-            if (isNullOrUndefined(noteIdRef.current)) return;
-            if (Number.isNaN(noteIdRef.current)) return;
-            if (!Number.isFinite(noteIdRef.current)) return;
+            const id = Number(noteIdRef.current);
+            if (!Number.isFinite(id)) return;
 
             if (!editor) return;
             if (editor.isEmpty) return;
@@ -27,7 +25,7 @@ function useSaveOnNavigate(editor: Editor, noteId: number) {
 
             blocksBulkUpdateCallbackRef.current(
                 serializedBlocks,
-                noteIdRef.current
+                id
             );
         };
     }, [editor]);

--- a/frontend/src/features/noteTaking/editor/hooks/editor/useSaveOnNavigate.hooks.ts
+++ b/frontend/src/features/noteTaking/editor/hooks/editor/useSaveOnNavigate.hooks.ts
@@ -28,7 +28,7 @@ function useSaveOnNavigate(editor: Editor, noteId: number) {
                 id
             );
         };
-    }, [editor]);
+    }, [editor, noteId]);
 }
 
 export default useSaveOnNavigate;

--- a/frontend/src/features/noteTaking/editor/hooks/editor/useSaveOnNavigate.hooks.ts
+++ b/frontend/src/features/noteTaking/editor/hooks/editor/useSaveOnNavigate.hooks.ts
@@ -8,13 +8,15 @@ import useLatest from "@/shared/hooks/useLatest.hooks";
 
 function useSaveOnNavigate(editor: Editor, noteId: number) {
     const { handleBlocksBulkUpdate } = useBlockMutations();
+
     const blocksBulkUpdateCallbackRef = useLatest(handleBlocksBulkUpdate);
+    const noteIdRef = useLatest(noteId);
 
     useEffect(() => {
         return () => {
-            if (isNullOrUndefined(noteId)) return;
-            if (Number.isNaN(noteId)) return;
-            if (!Number.isFinite(noteId)) return;
+            if (isNullOrUndefined(noteIdRef.current)) return;
+            if (Number.isNaN(noteIdRef.current)) return;
+            if (!Number.isFinite(noteIdRef.current)) return;
 
             if (!editor) return;
             if (editor.isEmpty) return;
@@ -25,7 +27,7 @@ function useSaveOnNavigate(editor: Editor, noteId: number) {
 
             blocksBulkUpdateCallbackRef.current(
                 serializedBlocks,
-                noteId
+                noteIdRef.current
             );
         };
     }, [editor]);

--- a/frontend/src/features/noteTaking/editor/hooks/editor/useSaveOnNavigate.hooks.ts
+++ b/frontend/src/features/noteTaking/editor/hooks/editor/useSaveOnNavigate.hooks.ts
@@ -3,10 +3,10 @@ import { useEffect } from "react";
 import { Editor } from "@tiptap/react";
 import { parseSerializedBlocks } from "../../utils/blocks.utils";
 import type { TiptapSerializedBlocks } from "../../types/blockSchema.types";
-import useBlockMutations from "../../hooks/blocks/useBlockMutations.hooks";
+import useBlockMutations from "../blocks/useBlockMutations.hooks";
 import useLatest from "@/shared/hooks/useLatest.hooks";
 
-function useNavigateSave(editor: Editor, noteId: number) {
+function useSaveOnNavigate(editor: Editor, noteId: number) {
     const { handleBlocksBulkUpdate } = useBlockMutations();
     const blocksBulkUpdateCallbackRef = useLatest(handleBlocksBulkUpdate);
 
@@ -31,4 +31,4 @@ function useNavigateSave(editor: Editor, noteId: number) {
     }, [editor]);
 }
 
-export default useNavigateSave;
+export default useSaveOnNavigate;

--- a/frontend/src/features/noteTaking/editor/pages/NotesEditorPage.tsx
+++ b/frontend/src/features/noteTaking/editor/pages/NotesEditorPage.tsx
@@ -8,20 +8,15 @@ import useNotesEditor from "../hooks/editor/useNotesEditor.hooks";
 import useEditorSelectionUpdate from "../hooks/editor/useEditorSelectionUpdate.hooks";
 import useEditorContentUpdate from "../hooks/editor/useEditorContentUpdate.hooks";
 import useBlocksQuery from "../hooks/blocks/useBlocksQuery.hooks";
-import { parseSerializedBlocks } from "../utils/blocks.utils";
-import type { TiptapSerializedBlocks } from "../types/blockSchema.types";
-import useBlockMutations from "../hooks/blocks/useBlockMutations.hooks";
 import useLatest from "@/shared/hooks/useLatest.hooks";
 import useWindowUnloadSave from "../hooks/editor/useWindowUnloadSave.hooks";
+import useSaveOnNavigate from "../hooks/editor/useSaveOnNavigate.hooks";
 
 function NotesEditorPage() {
     const { noteId } = useParams();
     const { data: blocks, isLoading, error } = useBlocksQuery();
     const { updateCurrentNoteId, clearCurrentNoteId } =
         useBlocksStore();
-    const { handleBlocksBulkUpdate } = useBlockMutations();
-
-    const blocksBulkUpdateCallbackRef = useLatest(handleBlocksBulkUpdate);
     const noteIdRef = useLatest(noteId);
 
     const editor = useNotesEditor();
@@ -48,26 +43,7 @@ function NotesEditorPage() {
     }, [blocks, editor]);
 
     useWindowUnloadSave(editor, Number(noteIdRef.current));
-
-    useEffect(() => {
-        return () => {
-            if (isNullOrUndefined(noteIdRef.current)) return;
-            if (Number.isNaN(Number(noteIdRef.current))) return;
-            if (!Number.isFinite(Number(noteIdRef.current))) return;
-
-            if (!editor) return;
-            if (editor.isEmpty) return;
-
-            const serializedBlocks = parseSerializedBlocks(
-                editor.getJSON().content as TiptapSerializedBlocks
-            );
-
-            blocksBulkUpdateCallbackRef.current(
-                serializedBlocks,
-                Number(noteIdRef.current)
-            );
-        };
-    }, [editor]);
+    useSaveOnNavigate(editor, Number(noteIdRef.current));
 
     useEditorSelectionUpdate(editor);
     useEditorContentUpdate(editor);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notes editor now auto-saves your changes when you navigate away or close the page.
* **Improvements**
  * More reliable preservation of edits across route changes, back navigation, and tab closes.
  * Reduces risk of losing unsaved work and ensures your latest content is restored when you return to a note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->