### PR TITLE
Editor bug fixes

### DIFF
--- a/backend/note_taking/serializers/block_list_serializer.py
+++ b/backend/note_taking/serializers/block_list_serializer.py
@@ -19,7 +19,10 @@ class BlockListSerializer(ListSerializer):
                 temp_block_id = item.pop("temp_block_id", None)
 
                 if not item.get("id"):
-                    greatest_position = Block.objects.filter(note=item["note"]).aggregate(max_position=Max("position")).get("max_position") or -1
+                    greatest_position = Block.objects.filter(note=item["note"]).aggregate(max_position=Max("position")).get("max_position")
+                    if greatest_position is None:
+                        greatest_position = -1
+                    
                     item["position"] = greatest_position + 1
                     try:
                         created_block = Block.objects.create(**item)

--- a/backend/note_taking/serializers/block_list_serializer.py
+++ b/backend/note_taking/serializers/block_list_serializer.py
@@ -13,17 +13,24 @@ class BlockListSerializer(ListSerializer):
         blocks = []
         with transaction.atomic():
             temp_id_mapping = {}
+            next_position_by_note = {}
 
             for item in validated_data:
                 item["note"] = item.pop("note_id", None)
                 temp_block_id = item.pop("temp_block_id", None)
 
                 if not item.get("id"):
-                    greatest_position = Block.objects.filter(note=item["note"]).aggregate(max_position=Max("position")).get("max_position")
-                    if greatest_position is None:
-                        greatest_position = -1
+                    note_obj = item.get("note")
+                    if note_obj not in next_position_by_note:
+                        max_position = Block.objects.filter(note=item["note"]).aggregate(max_position=Max("position")).get("max_position")
+                        if max_position is None:
+                            max_position = -1
+                        
+                        next_position_by_note[note_obj] = max_position + 1
                     
-                    item["position"] = greatest_position + 1
+                    item["position"] = next_position_by_note[note_obj]
+                    next_position_by_note[note_obj] += 1
+
                     try:
                         created_block = Block.objects.create(**item)
                         

--- a/backend/note_taking/serializers/block_list_serializer.py
+++ b/backend/note_taking/serializers/block_list_serializer.py
@@ -65,6 +65,8 @@ class BlockListSerializer(ListSerializer):
                                     block.content = item_content
                         else:
                             block.content = item.get("content", [])
+                    else:
+                        block.content = []
 
                     note_id = item.get("note_id")
                     if note_id:

--- a/frontend/src/features/noteTaking/editor/extensions/Title.node.ts
+++ b/frontend/src/features/noteTaking/editor/extensions/Title.node.ts
@@ -20,18 +20,21 @@ const Title = Node.create({
                 default: null,
                 renderHTML: () => ({}),
                 parseHTML: () => null,
+                keepOnSplit: false,
             },
 
             position: {
                 default: null,
                 renderHTML: () => ({}),
                 parseHTML: () => null,
+                keepOnSplit: false,
             },
             
             note: {
                 default: null,
                 renderHTML: () => ({}),
                 parseHTML: () => null,
+                keepOnSplit: true,
             },
         };
     },


### PR DESCRIPTION
Fixed issues with block creation and deletion in editor
- For editor block creation, ensured that title attributes do not get transferred to paragraphs on split to prevent duplicate IDs
- Also explicitly check for None in max_position calculation as using `aggregated_value or -1` can cause value truthy/falsy issues when `aggregated_value` is 0
- For block deletion, explicitly set content to a blank list to prevent issues where deletion causes absence of `content` key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects block ordering when adding new blocks, preventing misplacement at the start or end.
  * Ensures block content is cleared when removed during updates, aligning displayed content with edits.

* **New Features**
  * Improved title splitting in the editor: split titles now generate fresh identifiers and positions while preserving their note association, resulting in more predictable behavior when dividing titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->